### PR TITLE
doc(README.md): internal commands are also good examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ The `*dnscore.Resolver` API is compatible with `*net.Resolver`.
 
 See [example_resolver_test.go](example_resolver_test.go) for a complete example.
 
+See also [internal/cmd/lookup/main.go](internal/cmd/lookup/main.go) for a
+simple command line tool that demonstrates how to use the `*dnscore.Resolver` API.
+
 ### Low-Level Transport
 
 The `*dnscore.Transport` API provides granular control over DNS queries and responses.
@@ -47,6 +50,10 @@ See
 - [example_udp_test.go](example_udp_test.go)
 
 for complete examples using DNS over HTTPS, TCP, TLS, and UDP respectively.
+
+See also [internal/cmd/transport/main.go](internal/cmd/transport/main.go) for
+a simple command line tool that demonstrates how to use the `*dnscore.Transport` API
+along with using [log/slog](https://pkg.go.dev/log/slog) to emit structured logs.
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The `*dnscore.Resolver` API is compatible with `*net.Resolver`.
 See [example_resolver_test.go](example_resolver_test.go) for a complete example.
 
 See also [internal/cmd/lookup/main.go](internal/cmd/lookup/main.go) for a
-simple command line tool that demonstrates how to use the `*dnscore.Resolver` API.
+simple command line tool that demonstrates how to use the `*dnscore.Resolver` API
+along with [log/slog](https://pkg.go.dev/log/slog) to emit structured logs.
 
 ### Low-Level Transport
 
@@ -53,7 +54,7 @@ for complete examples using DNS over HTTPS, TCP, TLS, and UDP respectively.
 
 See also [internal/cmd/transport/main.go](internal/cmd/transport/main.go) for
 a simple command line tool that demonstrates how to use the `*dnscore.Transport` API
-along with using [log/slog](https://pkg.go.dev/log/slog) to emit structured logs.
+along with [log/slog](https://pkg.go.dev/log/slog) to emit structured logs.
 
 ## Design
 

--- a/internal/cmd/lookup/main.go
+++ b/internal/cmd/lookup/main.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// Command lookup shows how to use the resolver to perform a DNS lookup.
 package main
 
 import (

--- a/internal/cmd/mkcert/main.go
+++ b/internal/cmd/mkcert/main.go
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// Command mkcert generates a self-signed certificate for testing purposes.
 package main
 
 import "github.com/rbmk-project/common/selfsignedcert"

--- a/internal/cmd/transport/main.go
+++ b/internal/cmd/transport/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // Command transport shows how to use the transport to perform a DNS lookup.
 package main
 


### PR DESCRIPTION
While there, document internal commands and add missing SPDX-License-Identifier comment.