### PR TITLE
refactor: slog: Info => InfoContext

### DIFF
--- a/dohttps.go
+++ b/dohttps.go
@@ -59,7 +59,7 @@ func (t *Transport) queryHTTPS(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	t0 := t.maybeLogQuery(addr, rawQuery)
+	t0 := t.maybeLogQuery(ctx, addr, rawQuery)
 
 	// 2. The query is sent as the body of a POST request. The content-type
 	// header must be set. Otherwise servers may respond with 400.
@@ -96,6 +96,6 @@ func (t *Transport) queryHTTPS(ctx context.Context,
 	if err := resp.Unpack(rawResp); err != nil {
 		return nil, err
 	}
-	t.maybeLogResponse(addr, t0, rawQuery, rawResp)
+	t.maybeLogResponse(ctx, addr, t0, rawQuery, rawResp)
 	return resp, nil
 }

--- a/dotcp.go
+++ b/dotcp.go
@@ -81,7 +81,7 @@ func (t *Transport) queryStream(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	t0 := t.maybeLogQuery(addr, rawQuery)
+	t0 := t.maybeLogQuery(ctx, addr, rawQuery)
 
 	// 4. Wrap the query into a frame
 	rawQueryFrame, err := newRawMsgFrame(addr, rawQuery)
@@ -114,7 +114,7 @@ func (t *Transport) queryStream(ctx context.Context,
 	if err := resp.Unpack(rawResp); err != nil {
 		return nil, err
 	}
-	t.maybeLogResponse(addr, t0, rawQuery, rawResp)
+	t.maybeLogResponse(ctx, addr, t0, rawQuery, rawResp)
 	return resp, nil
 }
 

--- a/doudp_test.go
+++ b/doudp_test.go
@@ -147,7 +147,8 @@ func TestTransport_maybeLogQuery(t *testing.T) {
 			addr := &ServerAddr{Address: "8.8.8.8:53", Protocol: ProtocolUDP}
 			rawQuery := []byte{0, 0, 0, 0}
 
-			actualTime := transport.maybeLogQuery(addr, rawQuery)
+			ctx := context.Background()
+			actualTime := transport.maybeLogQuery(ctx, addr, rawQuery)
 
 			assert.Equal(t, tt.expectTime, actualTime)
 
@@ -200,7 +201,9 @@ func TestTransport_maybeLogResponse(t *testing.T) {
 			rawQuery := []byte{0, 0, 0, 0}
 			rawResponse := []byte{1, 1, 1, 1}
 
+			ctx := context.Background()
 			transport.maybeLogResponse(
+				ctx,
 				addr,
 				time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 				rawQuery,
@@ -436,7 +439,9 @@ func TestTransport_recvResponseUDP(t *testing.T) {
 				},
 			}
 
-			_, err := transport.recvResponseUDP(addr, conn, time.Now(), query, []byte{0, 0, 0, 0})
+			ctx := context.Background()
+			_, err := transport.recvResponseUDP(
+				ctx, addr, conn, time.Now(), query, []byte{0, 0, 0, 0})
 
 			if tt.expectedError != nil {
 				assert.Error(t, err)


### PR DESCRIPTION
The [log/slog](https://pkg.go.dev/log/slog#hdr-Contexts) docs say:

> It is recommended to pass a context to an output method if one is available.

So, let's just do this. The `log/slog` package would otherwise create and use a background context anyway.