### PR TITLE
feat(response_test.go): add test with equal prefixes

### DIFF
--- a/response_test.go
+++ b/response_test.go
@@ -108,6 +108,7 @@ func Test_equalASCIIName(t *testing.T) {
 		{"EqualNamesDifferentCase", "Example.COM.", "exaMple.com.", true},
 		{"DifferentNames", "example.com.", "example.org.", false},
 		{"DifferentLengths", "example.com.", "example.co.uk.", false},
+		{"OnlyPrefixMatch", "example.co.", "example.co.uk.", false},
 		{"EmptyStrings", "", "", true},
 		{"OneEmptyString", "example.com.", "", false},
 	}


### PR DESCRIPTION
The `example.co.` and `example.co.uk.` domains have equal prefixes but are different. Let us make sure we return false also in such a case, for extra robustness.