### PR TITLE
feat: save local and remote addr

### DIFF
--- a/dohttps.go
+++ b/dohttps.go
@@ -85,9 +85,12 @@ func (t *Transport) httpClientDo(req *http.Request) (*http.Response, netip.AddrP
 	}
 	req = req.WithContext(httptrace.WithClientTrace(traceCtx, trace))
 
-	// Perform the request and return the response.
+	// Perform the request and return the response while holding
+	// the mutex protecting laddr and raddr.
 	client := t.httpClient()
 	resp, err := client.Do(req)
+	mu.Lock()
+	defer mu.Unlock()
 	return resp, laddr, raddr, err
 }
 

--- a/dohttps.go
+++ b/dohttps.go
@@ -70,7 +70,7 @@ func (t *Transport) httpClientDo(req *http.Request) (*http.Response, netip.AddrP
 		}
 	}()
 
-	// Configure the trace for extractin laddr, raddr
+	// Configure the trace for extracting laddr, raddr
 	trace := &httptrace.ClientTrace{
 		GotConn: func(info httptrace.GotConnInfo) {
 			mu.Lock()

--- a/dotcp.go
+++ b/dotcp.go
@@ -114,7 +114,7 @@ func (t *Transport) queryStream(ctx context.Context,
 	if err := resp.Unpack(rawResp); err != nil {
 		return nil, err
 	}
-	t.maybeLogResponse(ctx, addr, t0, rawQuery, rawResp)
+	t.maybeLogResponseConn(ctx, addr, t0, rawQuery, rawResp, conn)
 	return resp, nil
 }
 

--- a/doudp.go
+++ b/doudp.go
@@ -10,7 +10,6 @@ package dnscore
 
 import (
 	"context"
-	"log/slog"
 	"net"
 	"time"
 
@@ -34,41 +33,6 @@ func (t *Transport) timeNow() time.Time {
 		return t.TimeNow()
 	}
 	return time.Now()
-}
-
-// maybeLogQuery is a helper function that logs the query if the logger is set
-// and returns the current time for subsequent logging.
-func (t *Transport) maybeLogQuery(
-	ctx context.Context, addr *ServerAddr, rawQuery []byte) time.Time {
-	t0 := t.timeNow()
-	if t.Logger != nil {
-		t.Logger.InfoContext(
-			ctx,
-			"dnsQuery",
-			slog.Any("rawQuery", rawQuery),
-			slog.String("serverAddr", addr.Address),
-			slog.String("serverProtocol", string(addr.Protocol)),
-			slog.Time("t", t0),
-		)
-	}
-	return t0
-}
-
-// maybeLogResponse is a helper function that logs the response if the logger is set.
-func (t *Transport) maybeLogResponse(ctx context.Context,
-	addr *ServerAddr, t0 time.Time, rawQuery, rawResp []byte) {
-	if t.Logger != nil {
-		t.Logger.InfoContext(
-			ctx,
-			"dnsResponse",
-			slog.Any("rawQuery", rawQuery),
-			slog.Any("rawResponse", rawResp),
-			slog.String("serverAddr", addr.Address),
-			slog.String("serverProtocol", string(addr.Protocol)),
-			slog.Time("t0", t0),
-			slog.Time("t", t.timeNow()),
-		)
-	}
 }
 
 // sendQueryUDP dials a connection, sends and logs the query and
@@ -146,7 +110,7 @@ func (t *Transport) recvResponseUDP(ctx context.Context, addr *ServerAddr, conn 
 	if err := resp.Unpack(rawResp); err != nil {
 		return nil, err
 	}
-	t.maybeLogResponse(ctx, addr, t0, rawQuery, rawResp)
+	t.maybeLogResponseConn(ctx, addr, t0, rawQuery, rawResp, conn)
 	return resp, nil
 }
 

--- a/slog.go
+++ b/slog.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dnscore
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/netip"
+	"time"
+)
+
+// addrToAddrPort converts a net.Addr to a netip.AddrPort.
+func addrToAddrPort(addr net.Addr) netip.AddrPort {
+	if addr == nil {
+		return netip.AddrPortFrom(netip.IPv6Unspecified(), 0)
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		return tcp.AddrPort()
+	}
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		return udp.AddrPort()
+	}
+	return netip.AddrPortFrom(netip.IPv6Unspecified(), 0)
+}
+
+// maybeLogQuery is a helper function that logs the query if the logger is set
+// and returns the current time for subsequent logging.
+func (t *Transport) maybeLogQuery(
+	ctx context.Context, addr *ServerAddr, rawQuery []byte) time.Time {
+	t0 := t.timeNow()
+	if t.Logger != nil {
+		t.Logger.InfoContext(
+			ctx,
+			"dnsQuery",
+			slog.Any("rawQuery", rawQuery),
+			slog.String("serverAddr", addr.Address),
+			slog.String("serverProtocol", string(addr.Protocol)),
+			slog.Time("t", t0),
+		)
+	}
+	return t0
+}
+
+// maybeLogResponseAddrPort is a helper function that logs the response if the logger is set.
+func (t *Transport) maybeLogResponseAddrPort(ctx context.Context,
+	addr *ServerAddr, t0 time.Time, rawQuery, rawResp []byte,
+	laddr, raddr netip.AddrPort) {
+	if t.Logger != nil {
+		// Convert zero values to unspecified
+		if !laddr.IsValid() {
+			laddr = netip.AddrPortFrom(netip.IPv6Unspecified(), 0)
+		}
+		if !raddr.IsValid() {
+			raddr = netip.AddrPortFrom(netip.IPv6Unspecified(), 0)
+		}
+
+		t.Logger.InfoContext(
+			ctx,
+			"dnsResponse",
+			slog.String("localAddr", laddr.String()),
+			slog.Any("rawQuery", rawQuery),
+			slog.Any("rawResponse", rawResp),
+			slog.String("remoteAddr", raddr.String()),
+			slog.String("serverAddr", addr.Address),
+			slog.String("serverProtocol", string(addr.Protocol)),
+			slog.Time("t0", t0),
+			slog.Time("t", t.timeNow()),
+		)
+	}
+}
+
+// maybeLogResponseConn is a helper function that logs the response if the logger is set.
+func (t *Transport) maybeLogResponseConn(ctx context.Context,
+	addr *ServerAddr, t0 time.Time, rawQuery, rawResp []byte,
+	conn net.Conn) {
+	if t.Logger != nil {
+		t.maybeLogResponseAddrPort(
+			ctx,
+			addr,
+			t0,
+			rawQuery,
+			rawResp,
+			addrToAddrPort(conn.LocalAddr()),
+			addrToAddrPort(conn.RemoteAddr()),
+		)
+	}
+}

--- a/slog_test.go
+++ b/slog_test.go
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package dnscore
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/rbmk-project/common/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_addrToAddrPort(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.Addr
+		want netip.AddrPort
+	}{
+		{
+			name: "nil address",
+			addr: nil,
+			want: netip.AddrPortFrom(netip.IPv6Unspecified(), 0),
+		},
+
+		{
+			name: "TCP address",
+			addr: &net.TCPAddr{
+				IP:   net.ParseIP("2001:db8::1"),
+				Port: 1234,
+			},
+			want: netip.MustParseAddrPort("[2001:db8::1]:1234"),
+		},
+
+		{
+			name: "UDP address",
+			addr: &net.UDPAddr{
+				IP:   net.ParseIP("2001:db8::2"),
+				Port: 5678,
+			},
+			want: netip.MustParseAddrPort("[2001:db8::2]:5678"),
+		},
+
+		{
+			name: "other address type",
+			addr: &net.UnixAddr{},
+			want: netip.AddrPortFrom(netip.IPv6Unspecified(), 0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addrToAddrPort(tt.addr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTransport_maybeLogQuery(t *testing.T) {
+	tests := []struct {
+		name       string
+		newLogger  func(w io.Writer) *slog.Logger
+		expectTime time.Time
+		expectLog  string
+	}{
+		{
+			name: "Logger set",
+			newLogger: func(w io.Writer) *slog.Logger {
+				return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+					Level: slog.LevelDebug,
+					ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+						if attr.Key == slog.TimeKey {
+							return slog.Attr{}
+						}
+						return attr
+					},
+				}))
+			},
+			expectTime: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expectLog:  "{\"level\":\"INFO\",\"msg\":\"dnsQuery\",\"rawQuery\":\"AAAAAA==\",\"serverAddr\":\"8.8.8.8:53\",\"serverProtocol\":\"udp\",\"t\":\"2020-01-01T00:00:00Z\"}\n",
+		},
+
+		{
+			name:       "Logger not set",
+			newLogger:  func(w io.Writer) *slog.Logger { return nil },
+			expectTime: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			expectLog:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			transport := &Transport{
+				Logger: tt.newLogger(&out),
+				TimeNow: func() time.Time {
+					return tt.expectTime
+				},
+			}
+
+			addr := &ServerAddr{Address: "8.8.8.8:53", Protocol: ProtocolUDP}
+			rawQuery := []byte{0, 0, 0, 0}
+
+			ctx := context.Background()
+			actualTime := transport.maybeLogQuery(ctx, addr, rawQuery)
+
+			assert.Equal(t, tt.expectTime, actualTime)
+
+			actualLog := out.String()
+			assert.Equal(t, tt.expectLog, actualLog)
+		})
+	}
+}
+
+func TestTransport_maybeLogResponseAddrPort(t *testing.T) {
+	tests := []struct {
+		name      string
+		newLogger func(w io.Writer) *slog.Logger
+		laddr     netip.AddrPort
+		raddr     netip.AddrPort
+		expectLog string
+	}{
+		{
+			name: "Logger set with valid addresses",
+			newLogger: func(w io.Writer) *slog.Logger {
+				return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+					Level: slog.LevelDebug,
+					ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+						if attr.Key == slog.TimeKey {
+							return slog.Attr{}
+						}
+						return attr
+					},
+				}))
+			},
+			laddr:     netip.MustParseAddrPort("[2001:db8::1]:1234"),
+			raddr:     netip.MustParseAddrPort("[2001:db8::2]:443"),
+			expectLog: "{\"level\":\"INFO\",\"msg\":\"dnsResponse\",\"localAddr\":\"[2001:db8::1]:1234\",\"rawQuery\":\"AAAAAA==\",\"rawResponse\":\"AQEBAQ==\",\"remoteAddr\":\"[2001:db8::2]:443\",\"serverAddr\":\"8.8.8.8:53\",\"serverProtocol\":\"udp\",\"t0\":\"2020-01-01T00:00:00Z\",\"t\":\"2020-01-01T00:00:11Z\"}\n",
+		},
+
+		{
+			name: "Logger set with invalid addresses",
+			newLogger: func(w io.Writer) *slog.Logger {
+				return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+					Level: slog.LevelDebug,
+					ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+						if attr.Key == slog.TimeKey {
+							return slog.Attr{}
+						}
+						return attr
+					},
+				}))
+			},
+			laddr:     netip.AddrPort{}, // invalid
+			raddr:     netip.AddrPort{}, // invalid
+			expectLog: "{\"level\":\"INFO\",\"msg\":\"dnsResponse\",\"localAddr\":\"[::]:0\",\"rawQuery\":\"AAAAAA==\",\"rawResponse\":\"AQEBAQ==\",\"remoteAddr\":\"[::]:0\",\"serverAddr\":\"8.8.8.8:53\",\"serverProtocol\":\"udp\",\"t0\":\"2020-01-01T00:00:00Z\",\"t\":\"2020-01-01T00:00:11Z\"}\n",
+		},
+
+		{
+			name:      "Logger not set",
+			newLogger: func(w io.Writer) *slog.Logger { return nil },
+			expectLog: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			transport := &Transport{
+				Logger: tt.newLogger(&out),
+				TimeNow: func() time.Time {
+					return time.Date(2020, 1, 1, 0, 0, 11, 0, time.UTC)
+				},
+			}
+
+			addr := &ServerAddr{Address: "8.8.8.8:53", Protocol: ProtocolUDP}
+			rawQuery := []byte{0, 0, 0, 0}
+			rawResponse := []byte{1, 1, 1, 1}
+
+			ctx := context.Background()
+			transport.maybeLogResponseAddrPort(
+				ctx,
+				addr,
+				time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+				rawQuery,
+				rawResponse,
+				tt.laddr,
+				tt.raddr,
+			)
+
+			actualLog := out.String()
+			assert.Equal(t, tt.expectLog, actualLog)
+		})
+	}
+}
+
+func TestTransport_maybeLogResponseConn(t *testing.T) {
+	tests := []struct {
+		name      string
+		newLogger func(w io.Writer) *slog.Logger
+		conn      net.Conn
+		expectLog string
+	}{
+		{
+			name: "Logger set with TCP addresses",
+			newLogger: func(w io.Writer) *slog.Logger {
+				return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+					Level: slog.LevelDebug,
+					ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+						if attr.Key == slog.TimeKey {
+							return slog.Attr{}
+						}
+						return attr
+					},
+				}))
+			},
+			conn: &mocks.Conn{
+				MockLocalAddr: func() net.Addr {
+					return &net.TCPAddr{
+						IP:   net.ParseIP("2001:db8::1"),
+						Port: 1234,
+					}
+				},
+				MockRemoteAddr: func() net.Addr {
+					return &net.TCPAddr{
+						IP:   net.ParseIP("2001:db8::2"),
+						Port: 443,
+					}
+				},
+			},
+			expectLog: "{\"level\":\"INFO\",\"msg\":\"dnsResponse\",\"localAddr\":\"[2001:db8::1]:1234\",\"rawQuery\":\"AAAAAA==\",\"rawResponse\":\"AQEBAQ==\",\"remoteAddr\":\"[2001:db8::2]:443\",\"serverAddr\":\"8.8.8.8:53\",\"serverProtocol\":\"udp\",\"t0\":\"2020-01-01T00:00:00Z\",\"t\":\"2020-01-01T00:00:11Z\"}\n",
+		},
+
+		{
+			name: "Logger set with non-TCP addresses",
+			newLogger: func(w io.Writer) *slog.Logger {
+				return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+					Level: slog.LevelDebug,
+					ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+						if attr.Key == slog.TimeKey {
+							return slog.Attr{}
+						}
+						return attr
+					},
+				}))
+			},
+			conn: &mocks.Conn{
+				MockLocalAddr: func() net.Addr {
+					return &net.UnixAddr{Name: "/tmp/local.sock", Net: "unix"}
+				},
+				MockRemoteAddr: func() net.Addr {
+					return &net.UnixAddr{Name: "/tmp/remote.sock", Net: "unix"}
+				},
+			},
+			expectLog: "{\"level\":\"INFO\",\"msg\":\"dnsResponse\",\"localAddr\":\"[::]:0\",\"rawQuery\":\"AAAAAA==\",\"rawResponse\":\"AQEBAQ==\",\"remoteAddr\":\"[::]:0\",\"serverAddr\":\"8.8.8.8:53\",\"serverProtocol\":\"udp\",\"t0\":\"2020-01-01T00:00:00Z\",\"t\":\"2020-01-01T00:00:11Z\"}\n",
+		},
+
+		{
+			name:      "Logger not set",
+			newLogger: func(w io.Writer) *slog.Logger { return nil },
+			conn:      &mocks.Conn{},
+			expectLog: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			transport := &Transport{
+				Logger: tt.newLogger(&out),
+				TimeNow: func() time.Time {
+					return time.Date(2020, 1, 1, 0, 0, 11, 0, time.UTC)
+				},
+			}
+
+			addr := &ServerAddr{Address: "8.8.8.8:53", Protocol: ProtocolUDP}
+			rawQuery := []byte{0, 0, 0, 0}
+			rawResponse := []byte{1, 1, 1, 1}
+
+			ctx := context.Background()
+			transport.maybeLogResponseConn(
+				ctx,
+				addr,
+				time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+				rawQuery,
+				rawResponse,
+				tt.conn,
+			)
+
+			actualLog := out.String()
+			assert.Equal(t, tt.expectLog, actualLog)
+		})
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"time"
 
 	"github.com/miekg/dns"
@@ -36,7 +37,18 @@ type Transport struct {
 
 	// HTTPClient is the optional HTTP client to use for DNS-over-HTTPS.
 	// If this field is nil, we use the  default HTTP client from [net/http].
+	//
+	// When HTTPClientDo is nil and this field is not nil, we use this client to
+	// perform queries and http/httptrace to obtain connection information.
 	HTTPClient *http.Client
+
+	// HTTPClientDo optionally allows full control over how HTTP requests
+	// are performed and how to obtain connection information. When this
+	// field is non-nil, it takes precedence over HTTPClient.
+	//
+	// This field is mainly useful for measurement scenarios where you need
+	// precise control over connection handling and addressing information.
+	HTTPClientDo func(req *http.Request) (*http.Response, netip.AddrPort, netip.AddrPort, error)
 
 	// Logger is the optional structured logger for emitting
 	// structured diagnostic events. If this field is nil, we


### PR DESCRIPTION
This changeset implements saving the local and remote addr for all the transports we support, improving data quality.

The changes should be obvious for all protocols but DoH, for which we introduced a lower-level mechanism to collect this info, and namely the HTTPClientDo function, opening up the possibility of advanced customization code to create a connection on the fly. The previous mechanism using HTTPClient is still working as intended.

Another minor change is refactoring the structured logging code inside the slog.go and slog_test.go files.