### PR TITLE
refactor(dnscoretest): embed io.Writer in ResponseWriter

### DIFF
--- a/dnscoretest/handler.go
+++ b/dnscoretest/handler.go
@@ -3,6 +3,7 @@
 package dnscoretest
 
 import (
+	"io"
 	"net"
 
 	"github.com/miekg/dns"
@@ -11,7 +12,7 @@ import (
 
 // ResponseWriter allows writing raw DNS responses.
 type ResponseWriter interface {
-	Write(rawMsg []byte) (int, error)
+	io.Writer
 }
 
 // Handler is a function that handles a DNS query.

--- a/serveraddr.go
+++ b/serveraddr.go
@@ -21,6 +21,10 @@ const (
 
 // ServerAddr is a DNS server address.
 //
+// While currently minimal, ServerAddr is designed as a pointer type to
+// allow for future extensions of server-specific properties (e.g., custom
+// headers for DoH) without requiring breaking API changes.
+//
 // Construct using [NewServerAddr].
 type ServerAddr struct {
 	// Protocol is the transport protocol to use.


### PR DESCRIPTION
This is more clear, obvious, and idiomatic.

While there, document by NewServerAddr constructs a pointer and other API functions expect a `*ServerAddr` value.