### PR TITLE
BREAKING CHANGE: remove NewResolver NewTransport

### DIFF
--- a/example_https_test.go
+++ b/example_https_test.go
@@ -17,7 +17,7 @@ import (
 
 func ExampleTransport_dnsOverHTTPS() {
 	// create transport, server addr, and query
-	txp := dnscore.NewTransport()
+	txp := &dnscore.Transport{}
 	serverAddr := &dnscore.ServerAddr{
 		Protocol: dnscore.ProtocolDoH,
 		Address:  "https://8.8.8.8/dns-query",

--- a/example_resolver_test.go
+++ b/example_resolver_test.go
@@ -14,7 +14,7 @@ import (
 
 func ExampleResolver() {
 	// create resolver
-	reso := dnscore.NewResolver()
+	reso := &dnscore.Resolver{}
 
 	// issue the queries and merge the responses
 	addrs, err := reso.LookupHost(context.Background(), "dns.google")

--- a/example_tcp_test.go
+++ b/example_tcp_test.go
@@ -17,7 +17,7 @@ import (
 
 func ExampleTransport_dnsOverTCP() {
 	// create transport, server addr, and query
-	txp := dnscore.NewTransport()
+	txp := &dnscore.Transport{}
 	serverAddr := &dnscore.ServerAddr{
 		Protocol: dnscore.ProtocolTCP,
 		Address:  "8.8.8.8:53",

--- a/example_tls_test.go
+++ b/example_tls_test.go
@@ -17,7 +17,7 @@ import (
 
 func ExampleTransport_dnsOverTLS() {
 	// create transport, server addr, and query
-	txp := dnscore.NewTransport()
+	txp := &dnscore.Transport{}
 	serverAddr := &dnscore.ServerAddr{
 		Protocol: dnscore.ProtocolDoT,
 		Address:  "8.8.8.8:853",

--- a/example_udp_test.go
+++ b/example_udp_test.go
@@ -17,7 +17,7 @@ import (
 
 func ExampleTransport_dnsOverUDP() {
 	// create transport, server addr, and query
-	txp := dnscore.NewTransport()
+	txp := &dnscore.Transport{}
 	serverAddr := &dnscore.ServerAddr{
 		Protocol: dnscore.ProtocolUDP,
 		Address:  "8.8.8.8:53",

--- a/internal/cmd/lookup/main.go
+++ b/internal/cmd/lookup/main.go
@@ -23,11 +23,11 @@ func main() {
 
 	// Set up the JSON logger
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{}))
-	transport := dnscore.NewTransport()
+	transport := &dnscore.Transport{}
 	transport.Logger = logger
 
 	// Create the resolver
-	reso := dnscore.NewResolver()
+	reso := &dnscore.Resolver{}
 	reso.Transport = transport
 
 	// Resolve the domain

--- a/internal/cmd/transport/main.go
+++ b/internal/cmd/transport/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	// Set up the JSON logger
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{}))
-	transport := dnscore.NewTransport()
+	transport := &dnscore.Transport{}
 	transport.Logger = logger
 
 	// Determine the DNS query type

--- a/resolver.go
+++ b/resolver.go
@@ -26,7 +26,7 @@ type ResolverTransport interface {
 // Resolver is a DNS resolver. This struct is API compatible with
 // the [*net.Resolver] struct from the [net] package.
 //
-// Construct using [NewResolver].
+// The zero value is ready to use.
 type Resolver struct {
 	// Config is the optional resolver configuration.
 	//
@@ -37,11 +37,6 @@ type Resolver struct {
 	//
 	// If nil, we use [DefaultTransport].
 	Transport ResolverTransport
-}
-
-// NewResolver creates a new DNS resolver with default settings.
-func NewResolver() *Resolver {
-	return &Resolver{}
 }
 
 // config returns the resolver configuration or a default one.

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -191,7 +191,7 @@ func TestResolver_LookupA(t *testing.T) {
 			rtm := &MockResolverTransport{
 				MockQuery: tt.mockQuery,
 			}
-			resolver := NewResolver()
+			resolver := &Resolver{}
 			resolver.Transport = rtm
 
 			addrs, err := resolver.LookupA(context.Background(), tt.host)
@@ -273,7 +273,7 @@ func TestResolver_LookupAAAA(t *testing.T) {
 			rtm := &MockResolverTransport{
 				MockQuery: tt.mockQuery,
 			}
-			resolver := NewResolver()
+			resolver := &Resolver{}
 			resolver.Transport = rtm
 
 			addrs, err := resolver.LookupAAAA(context.Background(), tt.host)
@@ -425,7 +425,7 @@ func TestResolver_LookupHost(t *testing.T) {
 			rtm := &MockResolverTransport{
 				MockQuery: tt.mockQuery,
 			}
-			resolver := NewResolver()
+			resolver := &Resolver{}
 			resolver.Transport = rtm
 
 			addrs, err := resolver.LookupHost(context.Background(), tt.host)

--- a/transport.go
+++ b/transport.go
@@ -19,7 +19,7 @@ import (
 
 // Transport allows sending and receiving DNS messages.
 //
-// Construct using [NewTransport].
+// The zero value is ready to use.
 //
 // A [*Transport] is safe for concurrent use by multiple goroutines
 // as long as you don't modify its fields after construction and the
@@ -80,12 +80,7 @@ type Transport struct {
 }
 
 // DefaultTransport is the default transport used by the package.
-var DefaultTransport = NewTransport()
-
-// NewTransport constructs a new [*Transport] with default settings.
-func NewTransport() *Transport {
-	return &Transport{}
-}
+var DefaultTransport = &Transport{}
 
 // ErrNoSuchTransportProtocol is returned when the given protocol is not supported.
 var ErrNoSuchTransportProtocol = errors.New("no such transport protocol")

--- a/transport_test.go
+++ b/transport_test.go
@@ -28,7 +28,7 @@ func TestTransportQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.protocol), func(t *testing.T) {
-			txp := NewTransport()
+			txp := &Transport{}
 			query := &dns.Msg{}
 			addr := NewServerAddr(tt.protocol, "")
 
@@ -61,7 +61,7 @@ func TestTransportQueryWithDuplicates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.protocol), func(t *testing.T) {
-			txp := NewTransport()
+			txp := &Transport{}
 			query := &dns.Msg{}
 			addr := NewServerAddr(tt.protocol, "")
 


### PR DESCRIPTION
This diff removes the NewResolver and NewTransport constructors, which were just constructing the zero value.

Semantically, I expect a constructor to create a valid value and I was not doing this. So, the simplest diff/fix for that is to just remove the constructors and their implicit promise they are constructing.

Users of `dnscore` will need to update their code accordinggly:

- replace `NewTransport()` with `&Transport{}`;

- replace `NewResolver()` with `&Resolver{}`.