### PR TITLE
doc(README.md): document minimum required Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ by providing building blocks for DNS queries and responses. It uses
 the widely-used [miekg/dns](https://github.com/miekg/dns) library for
 DNS message parsing and serialization.
 
+## Minimum Required Go Version
+
+We maintain compatibility with the oldest supported version of Go as
+documented by the [Go Release Policy](https://golang.org/doc/devel/release.html#policy)
+and update our minimum required version of Go as needed.
+
 ## Installation
 
 ```sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rbmk-project/dnscore
 
-go 1.23.3
+go 1.23
 
 require (
 	github.com/miekg/dns v1.1.63


### PR DESCRIPTION
While there, use `go1.23` in the `go.mod` file.